### PR TITLE
Update github templates and testing workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- *Before creating an issue please make sure you are using the latest version of mongoose -->
+<!-- *Before creating an issue please make sure you are using the latest version of mpath -->
 
 **Do you want to request a *feature* or report a *bug*?**
 
@@ -9,5 +9,3 @@
 **What is the expected behavior?**
 
 **What are the versions of Node.js and mpath are you are using? Note that "latest" is not a version.**
-
-<!-- You can print `mongoose.version` to get your current version of Mongoose: https://mongoosejs.com/docs/api.html#mongoose_Mongoose-version -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.
-
-If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.-->
 
 **Summary**
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-20.04
             mongo-os: ubuntu2004
             mongo: 5.0.2
+        exclude:
+          - node: 18
+            os: ubuntu-18.04 # nodejs 18 requires GLIBC_2.28, which ubuntu 18.04 does not have, earliest version is 18-10
     name: Node ${{ matrix.node }} MongoDB ${{ matrix.mongo }}
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16, 17]
+        node: [12, 14, 16, 18]
         os: [ubuntu-18.04, ubuntu-20.04]
         include:
           - os: ubuntu-18.04


### PR DESCRIPTION
**Summary**

This PR updates the templates for the context of `mpath` and updates the testing workflow to test nodejs 18 instead of 17